### PR TITLE
Fix to integrate preview email with Swoosh

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -37,7 +37,4 @@ config :coherence,
   layout: {Reunions.LayoutView, :app},
   opts: [:authenticatable, :recoverable, :lockable, :trackable, :unlockable_with_token, :invitable, :registerable]
 
-config :coherence, Reunions.Coherence.Mailer,
-  adapter: Swoosh.Adapters.Sendgrid,
-  api_key: System.get_env("SENDGRID_API_KEY")
 # %% End Coherence Configuration %%

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -41,3 +41,6 @@ config :reunions, Reunions.Repo,
   database: "reunions_dev",
   hostname: "localhost",
   pool_size: 10
+
+config :coherence, Reunions.Coherence.Mailer,
+  adapter: Swoosh.Adapters.Local

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -25,6 +25,11 @@ config :reunions, Reunions.Repo,
   url: System.get_env("DATABASE_URL"),
   pool_size: String.to_integer(System.get_env("POOL_SIZE") || "10"),
   ssl: true
+
+config :coherence, Reunions.Coherence.Mailer,
+  adapter: Swoosh.Adapters.Sendgrid,
+  api_key: System.get_env("SENDGRID_API_KEY")
+
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key

--- a/config/test.exs
+++ b/config/test.exs
@@ -17,3 +17,6 @@ config :reunions, Reunions.Repo,
   database: "reunions_test",
   hostname: "localhost",
   pool: Ecto.Adapters.SQL.Sandbox
+
+config :coherence, Reunions.Coherence.Mailer,
+  adapter: Swoosh.Adapters.Local

--- a/web/router.ex
+++ b/web/router.ex
@@ -49,4 +49,12 @@ defmodule Reunions.Router do
     # Add protected routes below
   end
 
+  if Mix.env == :dev do
+    scope "/dev" do
+      pipe_through [:browser]
+
+      forward "/mailbox", Plug.Swoosh.MailboxPreview, [base_path: "/dev/mailbox"]
+    end
+  end
+
 end

--- a/web/templates/layout/email.html.eex
+++ b/web/templates/layout/email.html.eex
@@ -1,0 +1,12 @@
+<div>
+  <p>Hello <%= @name %>!<p>
+  <p>
+    You have been invited to create an Account. Use the link below to create
+    an account.
+  </p>
+  <p>
+    <a href="<%= @url %>">Create my Account</a>
+  </p>
+  <p>Thank you!</p>
+</div>
+


### PR DESCRIPTION
https://github.com/Iowa-Elixir/reunions/issues/7

I setup the local to be able to visualize the email 'sent'
for :dev only.

I still have to check how to work with the coherence templates though.