### PR TITLE
silence warnings

### DIFF
--- a/priv/repo/migrations/20170412232737_create_coherence_user.exs
+++ b/priv/repo/migrations/20170412232737_create_coherence_user.exs
@@ -8,19 +8,19 @@ defmodule Reunions.Repo.Migrations.CreateCoherenceUser do
       add :password_hash, :string
       # recoverable
       add :reset_password_token, :string
-      add :reset_password_sent_at, :datetime
+      add :reset_password_sent_at, :utc_datetime
       # lockable
       add :failed_attempts, :integer, default: 0
-      add :locked_at, :datetime
+      add :locked_at, :utc_datetime
       # trackable
       add :sign_in_count, :integer, default: 0
-      add :current_sign_in_at, :datetime
-      add :last_sign_in_at, :datetime
+      add :current_sign_in_at, :utc_datetime
+      add :last_sign_in_at, :utc_datetime
       add :current_sign_in_ip, :string
       add :last_sign_in_ip, :string
       # unlockable_with_token
       add :unlock_token, :string
-      
+
       timestamps()
     end
     create unique_index(:users, [:email])

--- a/priv/repo/migrations/20170412232738_create_coherence_invitable.exs
+++ b/priv/repo/migrations/20170412232738_create_coherence_invitable.exs
@@ -5,7 +5,8 @@ defmodule Reunions.Repo.Migrations.CreateCoherenceInvitable do
       add :name, :string
       add :email, :string
       add :token, :string
-      timestamps
+
+      timestamps()
     end
     create unique_index(:invitations, [:email])
     create index(:invitations, [:token])

--- a/test/controllers/coherence_register_controller_test.exs
+++ b/test/controllers/coherence_register_controller_test.exs
@@ -2,10 +2,8 @@ defmodule Reunions.CoherenceRegisterControllerTest do
   use Reunions.ConnCase
   import Reunions.Router.Helpers
 
-  alias Reunions.User
   @base_attrs %{email: "some@content", name: "some content"}
   @valid_attrs Enum.into [password: "secret", password_confirmation: "secret"], @base_attrs
-  @invalid_attrs %{}
 
   setup %{conn: conn} do
     {:ok, conn: conn}


### PR DESCRIPTION
This branch fixes a few warnings that occur during the test suite build.  Mix recommends replacing the deprecated `datetime` field with `utc_datetime`.  I also added a missing pair of parentheses in a migration, and removed a couple unused variables in one of the controller tests.

I dropped and re-created my databases, but you can get away without.  The schema still lists `timestamp without time zone` as the field type.