### PR TITLE
Added basic CRUD for reunions

### DIFF
--- a/priv/repo/migrations/20170427021423_add_dateat_column_to_reunion.exs
+++ b/priv/repo/migrations/20170427021423_add_dateat_column_to_reunion.exs
@@ -3,7 +3,8 @@ defmodule Reunions.Repo.Migrations.CreateReunion do
 
   def change do
     alter table(:reunions) do
-      add :date_at, :utc_datetime
+      add :start_at, :utc_datetime
+      add :end_at, :utc_datetime
     end
   end
 end

--- a/priv/repo/migrations/20170427021423_add_dateat_column_to_reunion.exs
+++ b/priv/repo/migrations/20170427021423_add_dateat_column_to_reunion.exs
@@ -1,0 +1,9 @@
+defmodule Reunions.Repo.Migrations.CreateReunion do
+  use Ecto.Migration
+
+  def change do
+    alter table(:reunions) do
+      add :date_at, :utc_datetime
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -10,32 +10,13 @@
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
 
-alias Reunions.Repo
-alias Reunions.Reunion
-alias Reunions.User
+alias Reunions.{Repo, Reunion, User}
+
+import Ecto.Query
 
 # Clear tables
 Repo.delete_all Reunion
 Repo.delete_all User
-
-# Reunion seeds
-Reunion.changeset(%Reunion{}, %{
-  name: "Iowa Ruby Brigade",
-  location: "Des Moines, IA",
-  description: "The Iowa Ruby Brigade is a user group for Ruby and Rails enthusiasts."
-}) |> Repo.insert!
-
-Reunion.changeset(%Reunion{}, %{
-  name: "Iowa |> Elixir",
-  location: "Des Moines, IA",
-  description: "Iowa Elixir is a user group for Elixir and Phoenix enthusiasts."
-}) |> Repo.insert!
-
-Reunion.changeset(%Reunion{}, %{
-  name: "DSM Web Geeks",
-  location: "Des Moines, IA",
-  description: "We are a group of web enthusiasts with diverse interests covering the full spectrum of web and mobile design, development and marketing. We meet monthly and you are welcome to join."
-}) |> Repo.insert!
 
 # User seeds
 User.changeset(%User{}, %{
@@ -43,4 +24,64 @@ User.changeset(%User{}, %{
   email: "jl@joseluistorres.me",
   password: "secret",
   password_confirmation: "secret"
+}) |> Repo.insert!
+
+query = from u in User
+
+# Reunion seeds
+Reunion.changeset(%Reunion{}, %{
+  name: "Iowa Ruby Brigade",
+  location: "Des Moines, IA",
+  description: "The Iowa Ruby Brigade is a user group for Ruby and Rails enthusiasts.",
+  start_at: %{day: 17,
+               hour: 14,
+               min: 0,
+               month: 4,
+               sec: 0,
+              year: 2010},
+  end_at: %{day: 17,
+            hour: 14,
+            min: 0,
+            month: 4,
+            sec: 0,
+            year: 2010},
+  user_id: Repo.one(query).id
+}) |> Repo.insert!
+
+Reunion.changeset(%Reunion{}, %{
+  name: "Iowa |> Elixir",
+  location: "Des Moines, IA",
+  description: "Iowa Elixir is a user group for Elixir and Phoenix enthusiasts.",
+  start_at: %{day: 17,
+               hour: 14,
+               min: 0,
+               month: 4,
+               sec: 0,
+              year: 2010},
+  end_at: %{day: 17,
+            hour: 14,
+            min: 0,
+            month: 4,
+            sec: 0,
+            year: 2010},
+  user_id: Repo.one(query).id
+}) |> Repo.insert!
+
+Reunion.changeset(%Reunion{}, %{
+  name: "DSM Web Geeks",
+  location: "Des Moines, IA",
+  description: "We are a group of web enthusiasts with diverse interests covering the full spectrum of web and mobile design, development and marketing. We meet monthly and you are welcome to join.",
+  start_at: %{day: 17,
+               hour: 14,
+               min: 0,
+               month: 4,
+               sec: 0,
+              year: 2010},
+  end_at: %{day: 17,
+            hour: 14,
+            min: 0,
+            month: 4,
+            sec: 0,
+            year: 2010},
+  user_id: Repo.one(query).id
 }) |> Repo.insert!

--- a/test/controllers/reunion_controller_test.exs
+++ b/test/controllers/reunion_controller_test.exs
@@ -2,15 +2,23 @@ defmodule Reunions.ReunionControllerTest do
   use Reunions.ConnCase
 
   alias Reunions.{Reunion, User}
-  @valid_attrs %{date_at: %{day: 17,
-                            hour: 14,
-                            min: 0,
-                            month: 4,
-                            sec: 0,
-                            year: 2010},
-                 location: "some content",
+
+  @valid_attrs %{location: "some content",
                  description: String.duplicate("X", 50),
-                 name: "some content"}
+                 name: "some content",
+                 start_at: %{day: 17,
+                              hour: 14,
+                              min: 0,
+                              month: 4,
+                              sec: 0,
+                             year: 2010},
+                 end_at: %{day: 17,
+                           hour: 14,
+                           min: 0,
+                           month: 4,
+                           sec: 0,
+                           year: 2010}
+                  }
   @invalid_attrs %{}
 
   setup %{conn: conn} do

--- a/test/controllers/reunion_controller_test.exs
+++ b/test/controllers/reunion_controller_test.exs
@@ -1,7 +1,7 @@
 defmodule Reunions.ReunionControllerTest do
   use Reunions.ConnCase
 
-  alias Reunions.{Reunion, User}
+  alias Reunions.{Reunion, User, Repo}
 
   @valid_attrs %{location: "some content",
                  description: String.duplicate("X", 50),
@@ -41,8 +41,8 @@ defmodule Reunions.ReunionControllerTest do
     assert html_response(conn, 200) =~ "New reunion"
   end
 
-  test "creates resource and redirects when data is valid", %{conn: conn} do
-    conn = post conn, reunion_path(conn, :create), reunion: @valid_attrs
+  test "creates resource and redirects when data is valid", context do
+    conn = post context[:conn], reunion_path(context[:conn], :create), reunion: Map.merge(@valid_attrs, %{user_id: context[:user].id})
     assert redirected_to(conn) == reunion_path(conn, :index)
     assert Repo.get_by(Reunion, @valid_attrs)
   end
@@ -70,9 +70,9 @@ defmodule Reunions.ReunionControllerTest do
     assert html_response(conn, 200) =~ "Edit reunion"
   end
 
-  test "updates chosen resource and redirects when data is valid", %{conn: conn} do
+  test "updates chosen resource and redirects when data is valid", context do
     reunion = Repo.insert! %Reunion{}
-    conn = put conn, reunion_path(conn, :update, reunion), reunion: @valid_attrs
+    conn = put context[:conn], reunion_path(context[:conn], :update, reunion), reunion: Map.merge(@valid_attrs, %{user_id: context[:user].id})
     assert redirected_to(conn) == reunion_path(conn, :show, reunion)
     assert Repo.get_by(Reunion, @valid_attrs)
   end

--- a/test/controllers/reunion_controller_test.exs
+++ b/test/controllers/reunion_controller_test.exs
@@ -1,0 +1,84 @@
+defmodule Reunions.ReunionControllerTest do
+  use Reunions.ConnCase
+
+  alias Reunions.{Reunion, User}
+  @valid_attrs %{date_at: %{day: 17,
+                            hour: 14,
+                            min: 0,
+                            month: 4,
+                            sec: 0,
+                            year: 2010},
+                 location: "some content",
+                 description: String.duplicate("X", 50),
+                 name: "some content"}
+  @invalid_attrs %{}
+
+  setup %{conn: conn} do
+    user = User.changeset(%User{}, %{
+          name: "JoseLuis Torres",
+          email: "jl@joseluistorres.me",
+          password: "secret",
+          password_confirmation: "secret"
+        }) |> Repo.insert!
+    {:ok, conn: assign(conn, :current_user, user), user: user}
+  end
+
+  test "lists all entries on index", %{conn: conn} do
+    conn = get conn, reunion_path(conn, :index)
+    assert html_response(conn, 200) =~ "Listing reunions"
+  end
+
+  test "renders form for new resources", %{conn: conn} do
+    conn = get conn, reunion_path(conn, :new)
+    assert html_response(conn, 200) =~ "New reunion"
+  end
+
+  test "creates resource and redirects when data is valid", %{conn: conn} do
+    conn = post conn, reunion_path(conn, :create), reunion: @valid_attrs
+    assert redirected_to(conn) == reunion_path(conn, :index)
+    assert Repo.get_by(Reunion, @valid_attrs)
+  end
+
+  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+    conn = post conn, reunion_path(conn, :create), reunion: @invalid_attrs
+    assert html_response(conn, 200) =~ "New reunion"
+  end
+
+  test "shows chosen resource", %{conn: conn} do
+    reunion = Repo.insert! %Reunion{}
+    conn = get conn, reunion_path(conn, :show, reunion)
+    assert html_response(conn, 200) =~ "Show reunion"
+  end
+
+  test "renders page not found when id is nonexistent", %{conn: conn} do
+    assert_error_sent 404, fn ->
+      get conn, reunion_path(conn, :show, -1)
+    end
+  end
+
+  test "renders form for editing chosen resource", %{conn: conn} do
+    reunion = Repo.insert! %Reunion{}
+    conn = get conn, reunion_path(conn, :edit, reunion)
+    assert html_response(conn, 200) =~ "Edit reunion"
+  end
+
+  test "updates chosen resource and redirects when data is valid", %{conn: conn} do
+    reunion = Repo.insert! %Reunion{}
+    conn = put conn, reunion_path(conn, :update, reunion), reunion: @valid_attrs
+    assert redirected_to(conn) == reunion_path(conn, :show, reunion)
+    assert Repo.get_by(Reunion, @valid_attrs)
+  end
+
+  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
+    reunion = Repo.insert! %Reunion{}
+    conn = put conn, reunion_path(conn, :update, reunion), reunion: @invalid_attrs
+    assert html_response(conn, 200) =~ "Edit reunion"
+  end
+
+  test "deletes chosen resource", %{conn: conn} do
+    reunion = Repo.insert! %Reunion{}
+    conn = delete conn, reunion_path(conn, :delete, reunion)
+    assert redirected_to(conn) == reunion_path(conn, :index)
+    refute Repo.get(Reunion, reunion.id)
+  end
+end

--- a/test/models/reunion_test.exs
+++ b/test/models/reunion_test.exs
@@ -8,7 +8,13 @@ defmodule Reunions.ReunionTest do
       description: String.duplicate("X", 50),
       location: "some content",
       name: "some content",
-      user_id: 123
+      user_id: 123,
+      date_at: %{day: 17,
+                 hour: 14,
+                 min: 0,
+                 month: 4,
+                 sec: 0,
+                year: 2010}
     }
     changeset = Reunion.changeset(%Reunion{}, attrs)
     assert changeset.valid?
@@ -25,7 +31,13 @@ defmodule Reunions.ReunionTest do
       description: "some description",
       location: "some content",
       name: "some content",
-      user_id: 123
+      user_id: 123,
+      date_at: %{day: 17,
+                 hour: 14,
+                 min: 0,
+                 month: 4,
+                 sec: 0,
+                year: 2010}
     }
 
     changeset = Reunion.changeset(%Reunion{}, attrs)

--- a/test/models/reunion_test.exs
+++ b/test/models/reunion_test.exs
@@ -1,7 +1,7 @@
 defmodule Reunions.ReunionTest do
   use Reunions.ModelCase
 
-  alias Reunions.{Reunion, User}
+  alias Reunions.{Reunion}
 
   test "changeset with valid attributes" do
     attrs = %{

--- a/test/models/reunion_test.exs
+++ b/test/models/reunion_test.exs
@@ -9,11 +9,17 @@ defmodule Reunions.ReunionTest do
       location: "some content",
       name: "some content",
       user_id: 123,
-      date_at: %{day: 17,
-                 hour: 14,
-                 min: 0,
-                 month: 4,
-                 sec: 0,
+      start_at: %{day: 17,
+                   hour: 14,
+                   min: 0,
+                   month: 4,
+                   sec: 0,
+                  year: 2010},
+      end_at: %{day: 17,
+                hour: 14,
+                min: 0,
+                month: 4,
+                sec: 0,
                 year: 2010}
     }
     changeset = Reunion.changeset(%Reunion{}, attrs)
@@ -23,7 +29,7 @@ defmodule Reunions.ReunionTest do
   test "changeset is invalid without required attributes" do
     changeset = Reunion.changeset(%Reunion{}, %{})
     refute changeset.valid?
-    assert Enum.count(changeset.errors) == 4
+    assert Enum.count(changeset.errors) == 6
   end
 
   test "changeset is invalid with required attributes and description too short" do
@@ -32,11 +38,17 @@ defmodule Reunions.ReunionTest do
       location: "some content",
       name: "some content",
       user_id: 123,
-      date_at: %{day: 17,
-                 hour: 14,
-                 min: 0,
-                 month: 4,
-                 sec: 0,
+      start_at: %{day: 17,
+                   hour: 14,
+                   min: 0,
+                   month: 4,
+                   sec: 0,
+                  year: 2010},
+      end_at: %{day: 17,
+                hour: 14,
+                min: 0,
+                month: 4,
+                sec: 0,
                 year: 2010}
     }
 

--- a/web/controllers/reunion_controller.ex
+++ b/web/controllers/reunion_controller.ex
@@ -1,0 +1,65 @@
+defmodule Reunions.ReunionController do
+  use Reunions.Web, :controller
+
+  alias Reunions.Reunion
+
+  def index(conn, _params) do
+    reunions = Repo.all(Reunion)
+    render(conn, "index.html", reunions: reunions)
+  end
+
+  def new(conn, _params) do
+    changeset = Reunion.changeset(%Reunion{})
+    render(conn, "new.html", changeset: changeset)
+  end
+
+  def create(conn, %{"reunion" => reunion_params}) do
+    changeset = Reunion.changeset(%Reunion{}, reunion_params)
+
+    case Repo.insert(changeset) do
+      {:ok, _reunion} ->
+        conn
+        |> put_flash(:info, "Reunion created successfully.")
+        |> redirect(to: reunion_path(conn, :index))
+      {:error, changeset} ->
+        render(conn, "new.html", changeset: changeset)
+    end
+  end
+
+  def show(conn, %{"id" => id}) do
+    reunion = Repo.get!(Reunion, id)
+    render(conn, "show.html", reunion: reunion)
+  end
+
+  def edit(conn, %{"id" => id}) do
+    reunion = Repo.get!(Reunion, id)
+    changeset = Reunion.changeset(reunion)
+    render(conn, "edit.html", reunion: reunion, changeset: changeset)
+  end
+
+  def update(conn, %{"id" => id, "reunion" => reunion_params}) do
+    reunion = Repo.get!(Reunion, id)
+    changeset = Reunion.changeset(reunion, reunion_params)
+
+    case Repo.update(changeset) do
+      {:ok, reunion} ->
+        conn
+        |> put_flash(:info, "Reunion updated successfully.")
+        |> redirect(to: reunion_path(conn, :show, reunion))
+      {:error, changeset} ->
+        render(conn, "edit.html", reunion: reunion, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    reunion = Repo.get!(Reunion, id)
+
+    # Here we use delete! (with a bang) because we expect
+    # it to always work (and if it does not, it will raise).
+    Repo.delete!(reunion)
+
+    conn
+    |> put_flash(:info, "Reunion deleted successfully.")
+    |> redirect(to: reunion_path(conn, :index))
+  end
+end

--- a/web/models/reunion.ex
+++ b/web/models/reunion.ex
@@ -5,8 +5,9 @@ defmodule Reunions.Reunion do
     field :name, :string
     field :location, :string
     field :description, :string
+    field :start_at, Ecto.DateTime
+    field :end_at, Ecto.DateTime
     belongs_to :user, Reunions.User
-    field :date_at, Ecto.DateTime
 
     timestamps()
   end
@@ -16,8 +17,10 @@ defmodule Reunions.Reunion do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:name, :location, :description, :user_id, :date_at])
-    |> validate_required([:name, :location, :description, :user_id, :date_at])
+    |> cast(params, [:name, :location, :description, :user_id,
+                     :start_at, :end_at])
+    |> validate_required([:name, :location, :description, :user_id,
+                          :start_at, :end_at])
     |> validate_length(:description, min: 50)
   end
 end

--- a/web/models/reunion.ex
+++ b/web/models/reunion.ex
@@ -6,6 +6,7 @@ defmodule Reunions.Reunion do
     field :location, :string
     field :description, :string
     belongs_to :user, Reunions.User
+    field :date_at, Ecto.DateTime
 
     timestamps()
   end
@@ -15,8 +16,8 @@ defmodule Reunions.Reunion do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:name, :location, :description, :user_id])
-    |> validate_required([:name, :location, :description, :user_id])
+    |> cast(params, [:name, :location, :description, :user_id, :date_at])
+    |> validate_required([:name, :location, :description, :user_id, :date_at])
     |> validate_length(:description, min: 50)
   end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -47,6 +47,8 @@ defmodule Reunions.Router do
   scope "/", Reunions do
     pipe_through :protected
     # Add protected routes below
+
+    resources "/reunions", ReunionController
   end
 
   if Mix.env == :dev do

--- a/web/templates/reunion/edit.html.eex
+++ b/web/templates/reunion/edit.html.eex
@@ -1,0 +1,6 @@
+<h2>Edit reunion</h2>
+
+<%= render "form.html", changeset: @changeset,
+                        action: reunion_path(@conn, :update, @reunion) %>
+
+<%= link "Back", to: reunion_path(@conn, :index) %>

--- a/web/templates/reunion/form.html.eex
+++ b/web/templates/reunion/form.html.eex
@@ -1,0 +1,35 @@
+<%= form_for @changeset, @action, fn f -> %>
+  <%= if @changeset.action do %>
+    <div class="alert alert-danger">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= label f, :name, class: "control-label" %>
+    <%= text_input f, :name, class: "form-control" %>
+    <%= error_tag f, :name %>
+  </div>
+
+  <div class="form-group">
+    <%= label f, :description, class: "control-label" %>
+    <%= text_input f, :description, class: "form-control" %>
+    <%= error_tag f, :description %>
+  </div>
+
+  <div class="form-group">
+    <%= label f, :location, class: "control-label" %>
+    <%= text_input f, :location, class: "form-control" %>
+    <%= error_tag f, :location %>
+  </div>
+
+  <div class="form-group">
+    <%= label f, :date_at, class: "control-label" %>
+    <%= datetime_select f, :date_at, class: "form-control" %>
+    <%= error_tag f, :date_at %>
+  </div>
+
+  <div class="form-group">
+    <%= submit "Submit", class: "btn btn-primary" %>
+  </div>
+<% end %>

--- a/web/templates/reunion/form.html.eex
+++ b/web/templates/reunion/form.html.eex
@@ -24,9 +24,15 @@
   </div>
 
   <div class="form-group">
-    <%= label f, :date_at, class: "control-label" %>
-    <%= datetime_select f, :date_at, class: "form-control" %>
-    <%= error_tag f, :date_at %>
+    <%= label f, :start_at, class: "control-label" %>
+    <%= datetime_select f, :start_at, class: "form-control" %>
+    <%= error_tag f, :start_at %>
+  </div>
+
+  <div class="form-group">
+    <%= label f, :end_at, class: "control-label" %>
+    <%= datetime_select f, :end_at, class: "form-control" %>
+    <%= error_tag f, :end_at %>
   </div>
 
   <div class="form-group">

--- a/web/templates/reunion/index.html.eex
+++ b/web/templates/reunion/index.html.eex
@@ -5,7 +5,8 @@
     <tr>
       <th>Name</th>
       <th>Location</th>
-      <th>Date at</th>
+      <th>Start</th>
+      <th>End</th>
 
       <th></th>
     </tr>
@@ -15,7 +16,8 @@
     <tr>
       <td><%= reunion.name %></td>
       <td><%= reunion.location %></td>
-      <td><%= reunion.date_at %></td>
+      <td><%= reunion.start_at %></td>
+      <td><%= reunion.end_at %></td>
 
       <td class="text-right">
         <%= link "Show", to: reunion_path(@conn, :show, reunion), class: "btn btn-default btn-xs" %>

--- a/web/templates/reunion/index.html.eex
+++ b/web/templates/reunion/index.html.eex
@@ -1,0 +1,30 @@
+<h2>Listing reunions</h2>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Location</th>
+      <th>Date at</th>
+
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+<%= for reunion <- @reunions do %>
+    <tr>
+      <td><%= reunion.name %></td>
+      <td><%= reunion.location %></td>
+      <td><%= reunion.date_at %></td>
+
+      <td class="text-right">
+        <%= link "Show", to: reunion_path(@conn, :show, reunion), class: "btn btn-default btn-xs" %>
+        <%= link "Edit", to: reunion_path(@conn, :edit, reunion), class: "btn btn-default btn-xs" %>
+        <%= link "Delete", to: reunion_path(@conn, :delete, reunion), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %>
+      </td>
+    </tr>
+<% end %>
+  </tbody>
+</table>
+
+<%= link "New reunion", to: reunion_path(@conn, :new) %>

--- a/web/templates/reunion/new.html.eex
+++ b/web/templates/reunion/new.html.eex
@@ -1,0 +1,6 @@
+<h2>New reunion</h2>
+
+<%= render "form.html", changeset: @changeset,
+                        action: reunion_path(@conn, :create) %>
+
+<%= link "Back", to: reunion_path(@conn, :index) %>

--- a/web/templates/reunion/show.html.eex
+++ b/web/templates/reunion/show.html.eex
@@ -13,8 +13,13 @@
   </li>
 
   <li>
-    <strong>Date at:</strong>
-    <%= @reunion.date_at %>
+    <strong>Start:</strong>
+    <%= @reunion.start_at %>
+  </li>
+
+  <li>
+    <strong>End:</strong>
+    <%= @reunion.end_at %>
   </li>
 
 </ul>

--- a/web/templates/reunion/show.html.eex
+++ b/web/templates/reunion/show.html.eex
@@ -1,0 +1,23 @@
+<h2>Show reunion</h2>
+
+<ul>
+
+  <li>
+    <strong>Name:</strong>
+    <%= @reunion.name %>
+  </li>
+
+  <li>
+    <strong>Location:</strong>
+    <%= @reunion.location %>
+  </li>
+
+  <li>
+    <strong>Date at:</strong>
+    <%= @reunion.date_at %>
+  </li>
+
+</ul>
+
+<%= link "Edit", to: reunion_path(@conn, :edit, @reunion) %>
+<%= link "Back", to: reunion_path(@conn, :index) %>

--- a/web/views/reunion_view.ex
+++ b/web/views/reunion_view.ex
@@ -1,0 +1,3 @@
+defmodule Reunions.ReunionView do
+  use Reunions.Web, :view
+end


### PR DESCRIPTION
* add index, show, new, edit, _form views for Reunion models

* added a date_at column for reunions that will store the date and time that the reunion is supposed to take place at and made it a required field by adding date_at to the changeset validate_required

* new date_at column makes use of the Ecto.DateTime and uses the :utc_datetime type for storing date and time

* added reunion_controller tests and edited the reunion model tests to handle the new field

## Description
This adds the basic functionality to allow for creation, show, edit, delete functionality for reunion models.  Currently you will need to manually navigate to the `/reunions` path after logging in.  I figured we can tackle how to handle navigation when we handle scoping a list of reunions to a specific user.  I will also get a couple issues created to make sure we track those two use cases.

I tweaked the `reunion` model tests slightly to handle the new `date_at` field.

## Testing
Outline steps to test your changes.

1. After logging in go to `/reunions`
1. Try creating a new reunion
1. Try editing the reunion that you created

## To-Dos
- [x] create additional issues stemming from work here
- [x] remove `dates_at`
- [x] add `starts_at` and `ends_at`

## References
* [GitHub Issue 10](https://github.com/Iowa-Elixir/reunions/issues/10)